### PR TITLE
feat: open browser on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,14 @@ go build
 ./goWebU -db data.db -addr :8080
 ```
 
+When the server starts, it will attempt to open your default browser to
+`http://localhost:8080/`. If it does not open automatically, you can
+manually visit the URL.
+
 ## Web UI
 
-The server also hosts a tiny static interface for managing hosts and
-starting tunnels. Once running, open `http://localhost:8080/` in a web
-browser to access it.
+The server hosts a tiny static interface for managing hosts and starting
+tunnels.
 
 ### API Endpoints
 

--- a/main.go
+++ b/main.go
@@ -3,8 +3,12 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"log"
 	"net/http"
+	"os/exec"
+	"runtime"
+	"time"
 )
 
 func main() {
@@ -22,8 +26,30 @@ func main() {
 	}
 
 	srv := NewServer(db)
+
+	go func() {
+		// Allow the server a brief moment to start before opening the browser.
+		time.Sleep(200 * time.Millisecond)
+		openBrowser(fmt.Sprintf("http://localhost%s/", *addr))
+	}()
+
 	log.Printf("listening on %s", *addr)
 	if err := http.ListenAndServe(*addr, srv.routes()); err != nil {
 		log.Fatalf("server error: %v", err)
+	}
+}
+
+func openBrowser(url string) {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", url)
+	case "windows":
+		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", url)
+	default:
+		cmd = exec.Command("xdg-open", url)
+	}
+	if err := cmd.Start(); err != nil {
+		log.Printf("failed to open browser: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- launch default browser pointing at the web UI when the server starts
- document automatic browser launch in the README

## Testing
- `go fmt ./...`
- `go build ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a8420dde5c832991490d71659c7842