### PR TITLE
Allow reusing local ports on Windows

### DIFF
--- a/app/listen_unix.go
+++ b/app/listen_unix.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package app
+
+import "net"
+
+func listenLocal(addr string) (net.Listener, error) {
+	return net.Listen("tcp", addr)
+}

--- a/app/listen_windows.go
+++ b/app/listen_windows.go
@@ -1,0 +1,24 @@
+//go:build windows
+
+package app
+
+import (
+	"context"
+	"net"
+	"syscall"
+)
+
+func listenLocal(addr string) (net.Listener, error) {
+	lc := net.ListenConfig{
+		Control: func(network, address string, c syscall.RawConn) error {
+			var err error
+			if controlErr := c.Control(func(fd uintptr) {
+				err = syscall.SetsockoptInt(syscall.Handle(fd), syscall.SOL_SOCKET, syscall.SO_REUSEADDR, 1)
+			}); controlErr != nil {
+				return controlErr
+			}
+			return err
+		},
+	}
+	return lc.Listen(context.Background(), "tcp", addr)
+}

--- a/app/tunnel.go
+++ b/app/tunnel.go
@@ -47,7 +47,7 @@ func (t *Tunnel) StartForward(lport int, rhost string, rport int) error {
 		return fmt.Errorf("ssh connection not established")
 	}
 	localAddr := net.JoinHostPort("127.0.0.1", strconv.Itoa(lport))
-	ln, err := net.Listen("tcp", localAddr)
+	ln, err := listenLocal(localAddr)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary
- ensure SSH tunnel listener releases port promptly on Windows by enabling SO_REUSEADDR
- refactor tunnel start logic to use cross-platform listen helper

## Testing
- `go vet ./...`
- `go build ./...`

------
https://chatgpt.com/codex/tasks/task_e_68ab1111786883299f96b5b0d6b837b3